### PR TITLE
Simplify DOCKER_SOCKET Signal

### DIFF
--- a/src/signals/docker_socket.go
+++ b/src/signals/docker_socket.go
@@ -109,10 +109,10 @@ func (s *DockerSocketSignal) checkDarwinSocket(info os.FileInfo, socketPath stri
 			// This is Docker Desktop - check the actual socket permissions
 			targetInfo, err := os.Stat(targetPath)
 			if err != nil {
-				// Target doesn't exist - this is an orphaned symlink
-				s.issue = "orphaned"
-				s.orphanedPath = targetPath
-				return true
+				// Target doesn't exist - Docker Desktop not running
+				// This is normal, not a misconfiguration. Docker commands
+				// will fail fast with a clear error, not hang silently.
+				return false
 			}
 
 			// Check the actual socket permissions

--- a/src/signals/docker_socket_test.go
+++ b/src/signals/docker_socket_test.go
@@ -330,16 +330,11 @@ func TestDockerSocketSignal_MacOSOrphanedSymlink(t *testing.T) {
 		t.Fatalf("Failed to stat symlink: %v", err)
 	}
 
-	// Should trigger because symlink target doesn't exist
+	// Should NOT trigger - orphaned Docker Desktop symlink just means
+	// Docker isn't running, not a misconfiguration. Commands fail fast.
 	result := signal.checkDarwinSocket(info, symlinkPath)
-	if !result {
-		t.Error("Expected true for orphaned symlink")
-	}
-	if signal.issue != "orphaned" {
-		t.Errorf("Expected issue='orphaned', got '%s'", signal.issue)
-	}
-	if signal.orphanedPath != nonExistentTarget {
-		t.Errorf("Expected orphanedPath='%s', got '%s'", nonExistentTarget, signal.orphanedPath)
+	if result {
+		t.Error("Expected false for orphaned Docker Desktop symlink (not a real issue)")
 	}
 }
 


### PR DESCRIPTION
Summary of the change: In checkDarwinSocket(), when the Docker Desktop symlink target doesn't exist (Docker not running), we now return false instead of flagging it as "orphaned". The signal now only flags:

DOCKER_HOST misconfiguration - when DOCKER_HOST env var points to a non-existent socket (causes hangs) Overly permissive permissions - world-writable sockets (security issue)

An orphaned Docker Desktop symlink is just "Docker isn't running" - commands fail fast with a clear error, not a misconfiguration worth warning about.